### PR TITLE
Fix placement of populateBrickArray inside gameLoop

### DIFF
--- a/lib/gametime.js
+++ b/lib/gametime.js
@@ -113,8 +113,8 @@ function draw() {
 
 requestAnimationFrame(function gameLoop() {
   context.clearRect(0, 0, canvas.width, canvas.height);
-  populateBrickArray();
   draw();
+  populateBrickArray();
   paddleMove();
   ballMove();
   requestAnimationFrame(gameLoop);


### PR DESCRIPTION
The draw function clears as well, so had to move it below that.